### PR TITLE
도메인 설계

### DIFF
--- a/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiBoard.java
+++ b/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiBoard.java
@@ -1,0 +1,73 @@
+package com.pf.healthybox.domain.articleInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAiBoard is a Querydsl query type for AiBoard
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAiBoard extends EntityPathBase<AiBoard> {
+
+    private static final long serialVersionUID = -882276613L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAiBoard aiBoard = new QAiBoard("aiBoard");
+
+    public final com.pf.healthybox.domain.config.QAuditingFields _super = new com.pf.healthybox.domain.config.QAuditingFields(this);
+
+    public final QAiBoardPk aiBoardPk;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    public final StringPath productCode = createString("productCode");
+
+    public final StringPath sellerCode = createString("sellerCode");
+
+    public final StringPath title = createString("title");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public final StringPath writer = createString("writer");
+
+    public QAiBoard(String variable) {
+        this(AiBoard.class, forVariable(variable), INITS);
+    }
+
+    public QAiBoard(Path<? extends AiBoard> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAiBoard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAiBoard(PathMetadata metadata, PathInits inits) {
+        this(AiBoard.class, metadata, inits);
+    }
+
+    public QAiBoard(Class<? extends AiBoard> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.aiBoardPk = inits.isInitialized("aiBoardPk") ? new QAiBoardPk(forProperty("aiBoardPk")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiBoardPk.java
+++ b/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiBoardPk.java
@@ -1,0 +1,41 @@
+package com.pf.healthybox.domain.articleInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAiBoardPk is a Querydsl query type for AiBoardPk
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAiBoardPk extends BeanPath<AiBoardPk> {
+
+    private static final long serialVersionUID = -1759265194L;
+
+    public static final QAiBoardPk aiBoardPk = new QAiBoardPk("aiBoardPk");
+
+    public final EnumPath<com.pf.healthybox.domain.config.BoardCategory> boardCategory = createEnum("boardCategory", com.pf.healthybox.domain.config.BoardCategory.class);
+
+    public final EnumPath<com.pf.healthybox.domain.config.BoardGroup> boardGroup = createEnum("boardGroup", com.pf.healthybox.domain.config.BoardGroup.class);
+
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
+
+    public QAiBoardPk(String variable) {
+        super(AiBoardPk.class, forVariable(variable));
+    }
+
+    public QAiBoardPk(Path<? extends AiBoardPk> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAiBoardPk(PathMetadata metadata) {
+        super(AiBoardPk.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiReply.java
+++ b/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiReply.java
@@ -1,0 +1,67 @@
+package com.pf.healthybox.domain.articleInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QAiReply is a Querydsl query type for AiReply
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAiReply extends EntityPathBase<AiReply> {
+
+    private static final long serialVersionUID = -867783937L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QAiReply aiReply = new QAiReply("aiReply");
+
+    public final com.pf.healthybox.domain.config.QAuditingFields _super = new com.pf.healthybox.domain.config.QAuditingFields(this);
+
+    public final QAiReplyPk aiReplyPk;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public final StringPath writer = createString("writer");
+
+    public QAiReply(String variable) {
+        this(AiReply.class, forVariable(variable), INITS);
+    }
+
+    public QAiReply(Path<? extends AiReply> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QAiReply(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QAiReply(PathMetadata metadata, PathInits inits) {
+        this(AiReply.class, metadata, inits);
+    }
+
+    public QAiReply(Class<? extends AiReply> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.aiReplyPk = inits.isInitialized("aiReplyPk") ? new QAiReplyPk(forProperty("aiReplyPk")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiReplyPk.java
+++ b/src/main/generated/com/pf/healthybox/domain/articleInformation/QAiReplyPk.java
@@ -1,0 +1,43 @@
+package com.pf.healthybox.domain.articleInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAiReplyPk is a Querydsl query type for AiReplyPk
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QAiReplyPk extends BeanPath<AiReplyPk> {
+
+    private static final long serialVersionUID = -716705446L;
+
+    public static final QAiReplyPk aiReplyPk = new QAiReplyPk("aiReplyPk");
+
+    public final StringPath boardCategory = createString("boardCategory");
+
+    public final StringPath boardGroup = createString("boardGroup");
+
+    public final NumberPath<Long> boardIdx = createNumber("boardIdx", Long.class);
+
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
+
+    public QAiReplyPk(String variable) {
+        super(AiReplyPk.class, forVariable(variable));
+    }
+
+    public QAiReplyPk(Path<? extends AiReplyPk> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAiReplyPk(PathMetadata metadata) {
+        super(AiReplyPk.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/baseInformation/QBiPoint.java
+++ b/src/main/generated/com/pf/healthybox/domain/baseInformation/QBiPoint.java
@@ -21,7 +21,7 @@ public class QBiPoint extends EntityPathBase<BiPoint> {
 
     public final StringPath content = createString("content");
 
-    public final NumberPath<Integer> idx = createNumber("idx", Integer.class);
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
 
     public final DateTimePath<java.time.LocalDateTime> occurDate = createDateTime("occurDate", java.time.LocalDateTime.class);
 

--- a/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiBasket.java
+++ b/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiBasket.java
@@ -1,0 +1,45 @@
+package com.pf.healthybox.domain.orderInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QOiBasket is a Querydsl query type for OiBasket
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOiBasket extends EntityPathBase<OiBasket> {
+
+    private static final long serialVersionUID = -565437029L;
+
+    public static final QOiBasket oiBasket = new QOiBasket("oiBasket");
+
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
+
+    public final StringPath productCode = createString("productCode");
+
+    public final NumberPath<Integer> qty = createNumber("qty", Integer.class);
+
+    public final StringPath sellerCode = createString("sellerCode");
+
+    public final StringPath userId = createString("userId");
+
+    public QOiBasket(String variable) {
+        super(OiBasket.class, forVariable(variable));
+    }
+
+    public QOiBasket(Path<? extends OiBasket> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QOiBasket(PathMetadata metadata) {
+        super(OiBasket.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiDeliver.java
+++ b/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiDeliver.java
@@ -1,0 +1,47 @@
+package com.pf.healthybox.domain.orderInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QOiDeliver is a Querydsl query type for OiDeliver
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOiDeliver extends EntityPathBase<OiDeliver> {
+
+    private static final long serialVersionUID = 1534337008L;
+
+    public static final QOiDeliver oiDeliver = new QOiDeliver("oiDeliver");
+
+    public final StringPath address1 = createString("address1");
+
+    public final StringPath address2 = createString("address2");
+
+    public final EnumPath<com.pf.healthybox.domain.config.DeliveryFlag> deliveryFlag = createEnum("deliveryFlag", com.pf.healthybox.domain.config.DeliveryFlag.class);
+
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
+
+    public final StringPath userId = createString("userId");
+
+    public final StringPath zipcode = createString("zipcode");
+
+    public QOiDeliver(String variable) {
+        super(OiDeliver.class, forVariable(variable));
+    }
+
+    public QOiDeliver(Path<? extends OiDeliver> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QOiDeliver(PathMetadata metadata) {
+        super(OiDeliver.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiOrder.java
+++ b/src/main/generated/com/pf/healthybox/domain/orderInformation/QOiOrder.java
@@ -1,0 +1,71 @@
+package com.pf.healthybox.domain.orderInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QOiOrder is a Querydsl query type for OiOrder
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QOiOrder extends EntityPathBase<OiOrder> {
+
+    private static final long serialVersionUID = 964089049L;
+
+    public static final QOiOrder oiOrder = new QOiOrder("oiOrder");
+
+    public final com.pf.healthybox.domain.config.QAuditingFields _super = new com.pf.healthybox.domain.config.QAuditingFields(this);
+
+    public final NumberPath<Integer> amount = createNumber("amount", Integer.class);
+
+    public final StringPath apiCode = createString("apiCode");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    public final NumberPath<Long> deliverIdx = createNumber("deliverIdx", Long.class);
+
+    public final NumberPath<Long> idx = createNumber("idx", Long.class);
+
+    public final EnumPath<com.pf.healthybox.domain.config.PayMethod> payMethod = createEnum("payMethod", com.pf.healthybox.domain.config.PayMethod.class);
+
+    public final StringPath productCode = createString("productCode");
+
+    public final NumberPath<Integer> qty = createNumber("qty", Integer.class);
+
+    public final StringPath sellerCode = createString("sellerCode");
+
+    public final EnumPath<com.pf.healthybox.domain.config.Status> status = createEnum("status", com.pf.healthybox.domain.config.Status.class);
+
+    public final NumberPath<Integer> unitCost = createNumber("unitCost", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public final StringPath userId = createString("userId");
+
+    public QOiOrder(String variable) {
+        super(OiOrder.class, forVariable(variable));
+    }
+
+    public QOiOrder(Path<? extends OiOrder> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QOiOrder(PathMetadata metadata) {
+        super(OiOrder.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/productInformation/QPiDivProduct.java
+++ b/src/main/generated/com/pf/healthybox/domain/productInformation/QPiDivProduct.java
@@ -1,0 +1,55 @@
+package com.pf.healthybox.domain.productInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPiDivProduct is a Querydsl query type for PiDivProduct
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPiDivProduct extends EntityPathBase<PiDivProduct> {
+
+    private static final long serialVersionUID = 809668019L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPiDivProduct piDivProduct = new QPiDivProduct("piDivProduct");
+
+    public final StringPath categoryName = createString("categoryName");
+
+    public final StringPath groupName = createString("groupName");
+
+    public final StringPath isUsed = createString("isUsed");
+
+    public final QPiDivProductPk piDivProductPk;
+
+    public QPiDivProduct(String variable) {
+        this(PiDivProduct.class, forVariable(variable), INITS);
+    }
+
+    public QPiDivProduct(Path<? extends PiDivProduct> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPiDivProduct(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPiDivProduct(PathMetadata metadata, PathInits inits) {
+        this(PiDivProduct.class, metadata, inits);
+    }
+
+    public QPiDivProduct(Class<? extends PiDivProduct> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.piDivProductPk = inits.isInitialized("piDivProductPk") ? new QPiDivProductPk(forProperty("piDivProductPk")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/productInformation/QPiDivProductPk.java
+++ b/src/main/generated/com/pf/healthybox/domain/productInformation/QPiDivProductPk.java
@@ -1,0 +1,39 @@
+package com.pf.healthybox.domain.productInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPiDivProductPk is a Querydsl query type for PiDivProductPk
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QPiDivProductPk extends BeanPath<PiDivProductPk> {
+
+    private static final long serialVersionUID = 701888270L;
+
+    public static final QPiDivProductPk piDivProductPk = new QPiDivProductPk("piDivProductPk");
+
+    public final StringPath productCategory = createString("productCategory");
+
+    public final StringPath productGroup = createString("productGroup");
+
+    public QPiDivProductPk(String variable) {
+        super(PiDivProductPk.class, forVariable(variable));
+    }
+
+    public QPiDivProductPk(Path<? extends PiDivProductPk> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPiDivProductPk(PathMetadata metadata) {
+        super(PiDivProductPk.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/productInformation/QPiProduct.java
+++ b/src/main/generated/com/pf/healthybox/domain/productInformation/QPiProduct.java
@@ -1,0 +1,77 @@
+package com.pf.healthybox.domain.productInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPiProduct is a Querydsl query type for PiProduct
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPiProduct extends EntityPathBase<PiProduct> {
+
+    private static final long serialVersionUID = -1377953158L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPiProduct piProduct = new QPiProduct("piProduct");
+
+    public final com.pf.healthybox.domain.config.QAuditingFields _super = new com.pf.healthybox.domain.config.QAuditingFields(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    public final StringPath detail = createString("detail");
+
+    public final StringPath isUsed = createString("isUsed");
+
+    public final QPiProductPk piProductPk;
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final StringPath productCategory = createString("productCategory");
+
+    public final StringPath productGroup = createString("productGroup");
+
+    public final StringPath productName = createString("productName");
+
+    public final NumberPath<Integer> stock = createNumber("stock", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    //inherited
+    public final StringPath updatedBy = _super.updatedBy;
+
+    public QPiProduct(String variable) {
+        this(PiProduct.class, forVariable(variable), INITS);
+    }
+
+    public QPiProduct(Path<? extends PiProduct> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPiProduct(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPiProduct(PathMetadata metadata, PathInits inits) {
+        this(PiProduct.class, metadata, inits);
+    }
+
+    public QPiProduct(Class<? extends PiProduct> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.piProductPk = inits.isInitialized("piProductPk") ? new QPiProductPk(forProperty("piProductPk")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/pf/healthybox/domain/productInformation/QPiProductPk.java
+++ b/src/main/generated/com/pf/healthybox/domain/productInformation/QPiProductPk.java
@@ -1,0 +1,39 @@
+package com.pf.healthybox.domain.productInformation;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPiProductPk is a Querydsl query type for PiProductPk
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QPiProductPk extends BeanPath<PiProductPk> {
+
+    private static final long serialVersionUID = -1363055083L;
+
+    public static final QPiProductPk piProductPk = new QPiProductPk("piProductPk");
+
+    public final StringPath productCode = createString("productCode");
+
+    public final StringPath sellerCode = createString("sellerCode");
+
+    public QPiProductPk(String variable) {
+        super(PiProductPk.class, forVariable(variable));
+    }
+
+    public QPiProductPk(Path<? extends PiProductPk> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPiProductPk(PathMetadata metadata) {
+        super(PiProductPk.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/pf/healthybox/domain/articleInformation/AiBoard.java
+++ b/src/main/java/com/pf/healthybox/domain/articleInformation/AiBoard.java
@@ -1,4 +1,67 @@
 package com.pf.healthybox.domain.articleInformation;
 
-public class AiBoard {
+import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.config.BoardCategory;
+import com.pf.healthybox.domain.config.BoardGroup;
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_board")
+public class AiBoard extends AuditingFields {
+
+    @EmbeddedId AiBoardPk aiBoardPk;
+
+    @Setter @Column(nullable = false, length = 100) private String title;
+    @Setter @Column(nullable = false, length = 50) private String writer;
+    @Setter @Column(nullable = false, columnDefinition = "MEDIUMBLOB") private String content;
+    @Setter @Column(length = 8) private String sellerCode;
+    @Setter @Column(length = 8) private String productCode;
+
+    public AiBoard() {
+    }
+
+    public AiBoard(AiBoardPk aiBoardPk, String title, String writer, String content, String sellerCode, String productCode) {
+        this.aiBoardPk = aiBoardPk;
+        this.title = title;
+        this.writer = writer;
+        this.content = content;
+        this.sellerCode = sellerCode;
+        this.productCode = productCode;
+    }
+
+    public static AiBoard of(AiBoardPk aiBoardPk, String title, String writer, String content, String sellerCode, String productCode) {
+        return new AiBoard(aiBoardPk, title, writer, content, sellerCode, productCode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AiBoard aiBoard = (AiBoard) o;
+        return aiBoardPk.equals(aiBoard.aiBoardPk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aiBoardPk);
+    }
+}
+
+@Getter
+@RequiredArgsConstructor
+@Embeddable
+class AiBoardPk implements Serializable {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(length = 3) private BoardGroup boardGroup;
+
+    @Column(length = 3) private BoardCategory boardCategory;
+
 }

--- a/src/main/java/com/pf/healthybox/domain/articleInformation/AiReply.java
+++ b/src/main/java/com/pf/healthybox/domain/articleInformation/AiReply.java
@@ -1,4 +1,62 @@
 package com.pf.healthybox.domain.articleInformation;
 
-public class AiReply {
+import com.pf.healthybox.domain.config.AuditingFields;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_reply")
+public class AiReply extends AuditingFields {
+
+    @EmbeddedId private AiReplyPk aiReplyPk;
+
+    @Setter @Column(nullable = false, length = 50) private String writer;
+    @Setter @Column(nullable = false, columnDefinition = "TEXT") private String content;
+
+    public AiReply() {
+    }
+
+    public AiReply(AiReplyPk aiReplyPk, String writer, String content) {
+        this.aiReplyPk = aiReplyPk;
+        this.writer = writer;
+        this.content = content;
+    }
+
+    public static AiReply of(AiReplyPk aiReplyPk, String writer, String content) {
+        return new AiReply(aiReplyPk, writer, content);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AiReply aiReply = (AiReply) o;
+        return aiReplyPk.equals(aiReply.aiReplyPk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aiReplyPk);
+    }
+}
+
+@Getter
+@RequiredArgsConstructor
+@Embeddable
+class AiReplyPk implements Serializable {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column private Long boardIdx;
+    @Column(length = 3) private String boardGroup;
+    @Column(length = 3) private String boardCategory;
+
 }

--- a/src/main/java/com/pf/healthybox/domain/config/BoardCategory.java
+++ b/src/main/java/com/pf/healthybox/domain/config/BoardCategory.java
@@ -1,0 +1,20 @@
+package com.pf.healthybox.domain.config;
+
+import lombok.Getter;
+
+public enum BoardCategory {
+
+    NT("공지사항"),
+    EV("이벤트"),
+    TOA("홈페이지 문의"),
+    TOS("판매자 문의"),
+    FAQ("FAQ"),
+    RE("후기");
+
+    @Getter private final String description;
+
+    BoardCategory(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/config/BoardGroup.java
+++ b/src/main/java/com/pf/healthybox/domain/config/BoardGroup.java
@@ -1,0 +1,18 @@
+package com.pf.healthybox.domain.config;
+
+import lombok.Getter;
+
+public enum BoardGroup {
+
+    NT("공지사항"),
+    EV("이벤트"),
+    QA("문의"),
+    RE("후기");
+
+    @Getter private final String description;
+
+    BoardGroup(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/config/DeliveryFlag.java
+++ b/src/main/java/com/pf/healthybox/domain/config/DeliveryFlag.java
@@ -1,0 +1,15 @@
+package com.pf.healthybox.domain.config;
+
+import lombok.Getter;
+
+public enum DeliveryFlag {
+
+    NEW("단건 배송 정보"),
+    DEF("기본 배송 정보");
+
+    @Getter private final String description;
+
+    DeliveryFlag(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/pf/healthybox/domain/config/PayMethod.java
+++ b/src/main/java/com/pf/healthybox/domain/config/PayMethod.java
@@ -1,0 +1,16 @@
+package com.pf.healthybox.domain.config;
+
+import lombok.Getter;
+
+public enum PayMethod {
+
+    CARD("카드결제"),
+    CASH("현금결제");
+
+    @Getter private final String description;
+
+    PayMethod(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/config/Status.java
+++ b/src/main/java/com/pf/healthybox/domain/config/Status.java
@@ -1,0 +1,22 @@
+package com.pf.healthybox.domain.config;
+
+import lombok.Getter;
+
+public enum Status {
+
+    ORDERED("주문"),
+    BEFOREDELIVERY("출고"),
+    DELIVERING("배송중"),
+    AFTERDELIVERY("배송완료"),
+    RETURN("반품"),
+    EXCHANGE("교환"),
+    CANCEL("취소");
+
+    @Getter
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/orderInformation/OiBasket.java
+++ b/src/main/java/com/pf/healthybox/domain/orderInformation/OiBasket.java
@@ -1,4 +1,48 @@
 package com.pf.healthybox.domain.orderInformation;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_basket")
 public class OiBasket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false, length = 8) private String productCode;
+    @Setter @Column(nullable = false, length = 8) private String sellerCode;
+    @Setter @Column(nullable = false) private int qty;
+
+    public OiBasket() {}
+
+    public OiBasket(String userId, String productCode, String sellerCode, int qty) {
+        this.userId = userId;
+        this.productCode = productCode;
+        this.sellerCode = sellerCode;
+        this.qty = qty;
+    }
+
+    public static OiBasket of(String userId, String productCode, String sellerCode, int qty) {
+        return new OiBasket(userId, productCode, sellerCode, qty);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OiBasket oiBasket = (OiBasket) o;
+        return idx.equals(oiBasket.idx) && userId.equals(oiBasket.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idx, userId);
+    }
 }

--- a/src/main/java/com/pf/healthybox/domain/orderInformation/OiDeliver.java
+++ b/src/main/java/com/pf/healthybox/domain/orderInformation/OiDeliver.java
@@ -1,4 +1,52 @@
 package com.pf.healthybox.domain.orderInformation;
 
+import com.pf.healthybox.domain.config.DeliveryFlag;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_deliver")
 public class OiDeliver {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false, length = 5) private String zipcode;
+    @Setter @Column(nullable = false, length = 100) private String address1;
+    @Setter @Column(nullable = false, length = 100) private String address2;
+    @Setter @Column(nullable = false, length = 3) private DeliveryFlag deliveryFlag;
+
+    public OiDeliver() {
+    }
+
+    public OiDeliver(String userId, String zipcode, String address1, String address2, DeliveryFlag deliveryFlag) {
+        this.userId = userId;
+        this.zipcode = zipcode;
+        this.address1 = address1;
+        this.address2 = address2;
+        this.deliveryFlag = deliveryFlag;
+    }
+
+    public static OiDeliver of(String userId, String zipcode, String address1, String address2, DeliveryFlag deliveryFlag) {
+        return new OiDeliver(userId, zipcode, address1, address2, deliveryFlag);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OiDeliver oiDeliver = (OiDeliver) o;
+        return idx.equals(oiDeliver.idx);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idx);
+    }
 }

--- a/src/main/java/com/pf/healthybox/domain/orderInformation/OiOrder.java
+++ b/src/main/java/com/pf/healthybox/domain/orderInformation/OiOrder.java
@@ -1,4 +1,63 @@
 package com.pf.healthybox.domain.orderInformation;
 
-public class OiOrder {
+import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.config.PayMethod;
+import com.pf.healthybox.domain.config.Status;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_order")
+public class OiOrder extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Setter @Column(nullable = false, length = 20) private Status status;
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false) private Long deliverIdx;
+    @Setter @Column(nullable = false, length = 8) private String productCode;
+    @Setter @Column(nullable = false, length = 8) private String sellerCode;
+    @Setter @Column(nullable = false) private int qty;
+    @Setter @Column(nullable = false) private int unitCost;
+    @Setter @Column(nullable = false) private int amount;
+    @Setter @Column(nullable = false, length = 4) private PayMethod payMethod;
+    @Setter @Column(length = 30) private String apiCode;
+
+    public OiOrder() {}
+
+    public OiOrder(Status status, String userId, Long deliverIdx, String productCode, String sellerCode, int qty, int unitCost, int amount, PayMethod payMethod, String apiCode) {
+        this.status = status;
+        this.userId = userId;
+        this.deliverIdx = deliverIdx;
+        this.productCode = productCode;
+        this.sellerCode = sellerCode;
+        this.qty = qty;
+        this.unitCost = unitCost;
+        this.amount = amount;
+        this.payMethod = payMethod;
+        this.apiCode = apiCode;
+    }
+
+    public static OiOrder of(Status status, String userId, Long deliverIdx, String productCode, String sellerCode, int qty, int unitCost, int amount, PayMethod payMethod, String apiCode) {
+        return new OiOrder(status, userId, deliverIdx, productCode, sellerCode, qty, unitCost, amount, payMethod, apiCode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OiOrder oiOrder = (OiOrder) o;
+        return idx.equals(oiOrder.idx);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idx);
+    }
 }

--- a/src/main/java/com/pf/healthybox/domain/productInformation/PiDivProduct.java
+++ b/src/main/java/com/pf/healthybox/domain/productInformation/PiDivProduct.java
@@ -1,4 +1,59 @@
 package com.pf.healthybox.domain.productInformation;
 
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_div_product")
 public class PiDivProduct {
+
+    @EmbeddedId
+    private PiDivProductPk piDivProductPk;
+
+    @Setter @Column(nullable = false, length = 50) private String groupName;
+    @Setter @Column(nullable = false, length = 50) private String categoryName;
+    @Setter @Column(nullable = false, length = 1) private String isUsed;
+
+    public PiDivProduct() {}
+
+    public PiDivProduct(PiDivProductPk piDivProductPk, String groupName, String categoryName, String isUsed) {
+        this.piDivProductPk = piDivProductPk;
+        this.groupName = groupName;
+        this.categoryName = categoryName;
+        this.isUsed = isUsed;
+    }
+
+    public static PiDivProduct of(PiDivProductPk piDivProductPk, String groupName, String categoryName, String isUsed) {
+        return new PiDivProduct(piDivProductPk, groupName, categoryName, isUsed);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PiDivProduct that = (PiDivProduct) o;
+        return piDivProductPk.equals(that.piDivProductPk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(piDivProductPk);
+    }
+}
+
+@Getter
+@RequiredArgsConstructor
+@Embeddable
+class PiDivProductPk implements Serializable {
+
+    @Column(length = 3)
+    private String productGroup;
+
+    @Column(length = 3)
+    private String productCategory;
+
 }

--- a/src/main/java/com/pf/healthybox/domain/productInformation/PiProduct.java
+++ b/src/main/java/com/pf/healthybox/domain/productInformation/PiProduct.java
@@ -1,4 +1,66 @@
 package com.pf.healthybox.domain.productInformation;
 
-public class PiProduct {
+import com.pf.healthybox.domain.config.AuditingFields;
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "tbl_product")
+public class PiProduct extends AuditingFields {
+
+    @EmbeddedId
+    private PiProductPk piProductPk;
+
+    @Setter@Column(nullable = false, length = 50) private String productName;
+    @Setter @Column(nullable = false, length = 3) private String productGroup;
+    @Setter @Column(nullable = false, length = 3) private String productCategory;
+    @Setter @Column(nullable = false) private int price;
+    @Setter @Column(nullable = false) private int stock;
+    @Setter @Column(nullable = false, columnDefinition = "MEDIUMBLOB") private String detail;
+    @Setter @Column(nullable = false, length = 1) private String isUsed;
+
+    public PiProduct() {}
+
+    public PiProduct(PiProductPk piProductPk, String productName, String productGroup, String productCategory, int price, int stock, String detail, String isUsed) {
+        this.piProductPk = piProductPk;
+        this.productName = productName;
+        this.productGroup = productGroup;
+        this.productCategory = productCategory;
+        this.price = price;
+        this.stock = stock;
+        this.detail = detail;
+        this.isUsed = isUsed;
+    }
+
+    public static PiProduct of(PiProductPk piProductPk, String productName, String productGroup, String productCategory, int price, int stock, String detail, String isUsed) {
+        return new PiProduct(piProductPk, productName, productGroup, productCategory, price, stock, detail, isUsed);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PiProduct piProduct = (PiProduct) o;
+        return piProductPk.equals(piProduct.piProductPk);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(piProductPk);
+    }
+}
+
+@Getter
+@RequiredArgsConstructor
+@Embeddable
+class PiProductPk implements Serializable {
+
+    @Column(length = 8) private String productCode;
+
+    @Column(length = 8) private String sellerCode;
+
 }


### PR DESCRIPTION
이전 PR 이후 남은 도메인의 설계 진행
* 주문정보
  * 장바구니
  * 주문정보
  * 배송정보
* 품목정보
  * 품목정보
  * 품목분류
* 게시판
  * 게시판
  * 댓글

리스트에 대한 도메인이 설계되었으며 도메인 설계 중 사용된 예약어 및 가독성을 위한 이름 변경이 있었음
해당 `commit`는 `draw.io`에서 진행되어 상세내역은 작성되지 않았으나 일반적인 수정사항은 다음과 같음
* `name` 등 테이블 마다 중복되는 컬럼 명칭은 각 테이블 명칭을 컬럼 명칭 앞에 추가하여가독성을 높임
* `group` 등 SQL 구문에서 사용되는 예약어의 경우도 컬럼 명칭 앞에 테이블 명칭을 추가하여 변경함

This closes #10 