### PR TITLE
로그인 페이지 마크업 추가

### DIFF
--- a/src/main/java/com/pf/healthybox/contoller/UserManageController.java
+++ b/src/main/java/com/pf/healthybox/contoller/UserManageController.java
@@ -13,4 +13,9 @@ public class UserManageController { // 유저 관리에 대한 컨트롤러(회�
         return "userTemplates/signUp";
     }
 
+    @GetMapping("/login")
+    public String showLogin() {
+        return "userTemplates/login";
+    }
+
 }

--- a/src/main/resources/static/css/compProperties.css
+++ b/src/main/resources/static/css/compProperties.css
@@ -22,10 +22,26 @@
 }
 
 .joinATag:hover {
-    color: white;
+    color: rgba(83, 146, 91, 0.8);
 }
 
 .requiredData {
     color: rgba(255,0,0,0.8);
     font-size: small;
+}
+
+/* user/login 페이지 */
+.loginATag {
+    color: rgba(83,146,91,0.8);
+    width: 120px;
+    background-color: #F8F9FA;
+    border: 1px solid #F8F9FA;
+    display: block;
+    text-decoration: none;
+    text-align: center;
+    line-height: 38px;
+}
+
+.loginATag.hover {
+    color: rgba(83,146,91,0.8);
 }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -16,7 +16,7 @@
                 </a>
 
                 <div id="userMenu" class="col-md-3 text-end">
-                    <button type="button" class="btn btn-outline-success me-2">Login</button>
+                    <button id="loginBtn" type="button" class="btn btn-outline-success me-2">Login</button>
                     <button id="signUpBtn" type="button" class="btn btn-success">Sign-up</button>
                 </div>
             </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
 <thlogic>
     <attr sel="#signUpBtn" th:onclick="|window.location.href='/user/signUp'|"/>
+    <attr sel="#loginBtn" th:onclick="|window.location.href='/user/login'|"/>
 </thlogic>

--- a/src/main/resources/templates/userTemplates/login.html
+++ b/src/main/resources/templates/userTemplates/login.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="">
+    <meta name="author" content="JH">
+    <title>Healthy Box</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/colors.css" rel="stylesheet">
+    <link href="/css/compProperties.css" rel="stylesheet">
+
+</head>
+<body>
+
+    <header id="header">
+        헤더 삽입부
+        <hr>
+    </header>
+
+    <main class="container d-flex flex-wrap align-items-center justify-content-center py-4 bg-light">
+        <form class="col-3 align-items-center justify-content-center text-center" >
+            <h4 class="mb-6">Login</h4>
+
+            <div class="borderTop my-2"></div>
+
+            <div class="form-floating my-3">
+                <input type="text" class="form-control" id="floatingInput" placeholder="ID">
+                <label for="floatingInput">ID</label>
+            </div>
+
+            <div class="form-floating my-3">
+                <input type="password" class="form-control" id="floatingPassword" placeholder="Password">
+                <label for="floatingPassword">Password</label>
+            </div>
+
+            <div class="checkbox my-3">
+                <label>
+                    <input type="checkbox" value="remember-me"> Remember me
+                </label>
+            </div>
+            <div class="d-flex flex-wrap align-items-center justify-content-center">
+                <button class="joinBtn" type="submit">Log in</button>
+                <div class="mx-2"></div>
+                <a href="/user/signUp" class="joinATag">Sign-Up</a>
+            </div>
+            <div class="d-flex flex-wrap align-times-center justify-content-center">
+                <a href="#" class="loginATag">아이디 찾기</a>
+                <div class="mx-2"></div>
+                <a href="#" class="loginATag">비밀번호 찾기</a>
+            </div>
+        </form>
+    </main>
+
+    <footer id="footer">
+        <hr>
+        푸터 삽입부
+    </footer>
+
+</body>
+</html>

--- a/src/main/resources/templates/userTemplates/login.th.xml
+++ b/src/main/resources/templates/userTemplates/login.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#footer" th:replace="footer :: footer"/>
+</thlogic>

--- a/src/main/resources/templates/userTemplates/signUp.html
+++ b/src/main/resources/templates/userTemplates/signUp.html
@@ -16,7 +16,7 @@
         <hr>
     </header>
 
-    <main class="container bg-light" style="width:1296px">
+    <main class="container bg-light border-top" style="width:1296px">
         <div class="py-5 text-center ">
             <h2>회원가입</h2>
             <p class="lead">일반회원(사업자 회원)으로 회원가입을 위해 아래 정보를 입력해주세요.</p>
@@ -133,7 +133,7 @@
                             <div class="d-flex flex-wrap justify-content-end">
                                 <button class="joinBtn " type="submit">회원가입</button>
                                 <div class="mx-3"></div>
-                                <a href="javascript:history.back();" class="joinATag ">취소</a>
+                                <a href="/" class="joinATag ">취소</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
로그인 페이지 마크업 추가
* 로그인 페이지 마크업 `login.html`과 디커플로직 관리를 위한 `login.th.xml` 파일 추가됨
* `header.html`과 `header.th.xml` 수정을 통해 홈페이지 헤더의 `Login`버튼을 통해 로그인 마크업 페이지로 이동 가능하도록 기능 연결
* `compProperties.css` 파일에 로그인 파일에 사용되는 스타일 서식 추가
* 회원가입 페이지에서 취소 버튼 클릭시 뒤로가기 버튼에서 홈페이지의 메인 페이지로 이동하도록 `signUp.html`파일 수정

This closes #20 