### PR TITLE
회원가입 페이지 서비스 및 컨트롤러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     //queryDSL 설정

--- a/src/main/java/com/pf/healthybox/config/JpaConfig.java
+++ b/src/main/java/com/pf/healthybox/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.pf.healthybox.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/java/com/pf/healthybox/contoller/apiController/UserManageApiController.java
+++ b/src/main/java/com/pf/healthybox/contoller/apiController/UserManageApiController.java
@@ -1,0 +1,43 @@
+package com.pf.healthybox.contoller.apiController;
+
+import com.pf.healthybox.domain.baseInformation.BiUser;
+import com.pf.healthybox.dto.baseInformationDto.BiUserDto;
+import com.pf.healthybox.dto.request.baseInformationReq.BiUserRequest;
+import com.pf.healthybox.dto.response.baseInformationRes.BiUserResponse;
+import com.pf.healthybox.service.BiUserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@RequestMapping("/api/user-manage")
+@RestController
+public class UserManageApiController {
+
+    private final BiUserService biUserService;
+
+    public UserManageApiController(BiUserService biUserService) {
+        this.biUserService = biUserService;
+    }
+
+    //회원가입
+    @PostMapping("/sign-up")
+    public void signUp(@RequestBody BiUserRequest req) {
+        biUserService.signUp(req.toDto());
+    }
+
+    //회원 탈퇴
+    @DeleteMapping("/delete-user")
+    public void deleteUser(@RequestParam String userId, @RequestParam String userPw) {
+        BiUserResponse user = biUserService.showUserInfo(userId);
+        if (user.userPw().equals(userPw)) {
+            biUserService.deleteUser(userId, userPw);
+        }
+    }
+
+
+    //연락처 인증
+
+
+}

--- a/src/main/java/com/pf/healthybox/domain/AuditingFields.java
+++ b/src/main/java/com/pf/healthybox/domain/AuditingFields.java
@@ -1,4 +1,4 @@
-package com.pf.healthybox.domain.config;
+package com.pf.healthybox.domain;
 
 import lombok.Getter;
 import lombok.ToString;
@@ -25,17 +25,17 @@ public class AuditingFields {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt; //생성 일자
 
-    @CreatedBy
-    @Column(nullable = false, updatable = false, length = 50)
-    private String createdBy; // 생성자
+//    @CreatedBy
+//    @Column(nullable = false, updatable = false, length = 50)
+//    private String createdBy; // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = true)
     private LocalDateTime updatedAt; // 수정 일자
 
-    @LastModifiedBy
-    @Column(nullable = false, updatable = false, length = 50)
-    private String updatedBy;
+//    @LastModifiedBy
+//    @Column(nullable = false, length = 50)
+//    private String updatedBy;
 
 }

--- a/src/main/java/com/pf/healthybox/domain/articleInformation/AiBoard.java
+++ b/src/main/java/com/pf/healthybox/domain/articleInformation/AiBoard.java
@@ -1,12 +1,9 @@
 package com.pf.healthybox.domain.articleInformation;
 
-import com.pf.healthybox.domain.config.AuditingFields;
-import com.pf.healthybox.domain.config.BoardCategory;
-import com.pf.healthybox.domain.config.BoardGroup;
+import com.pf.healthybox.domain.AuditingFields;
 import lombok.*;
 
 import javax.persistence.*;
-import java.io.Serializable;
 import java.util.Objects;
 
 @Getter

--- a/src/main/java/com/pf/healthybox/domain/articleInformation/AiReply.java
+++ b/src/main/java/com/pf/healthybox/domain/articleInformation/AiReply.java
@@ -1,13 +1,10 @@
 package com.pf.healthybox.domain.articleInformation;
 
-import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.AuditingFields;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
-import java.io.Serializable;
 import java.util.Objects;
 
 @Getter

--- a/src/main/java/com/pf/healthybox/domain/baseInformation/BiSeller.java
+++ b/src/main/java/com/pf/healthybox/domain/baseInformation/BiSeller.java
@@ -1,6 +1,6 @@
 package com.pf.healthybox.domain.baseInformation;
 
-import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.AuditingFields;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/pf/healthybox/domain/baseInformation/BiUser.java
+++ b/src/main/java/com/pf/healthybox/domain/baseInformation/BiUser.java
@@ -1,7 +1,7 @@
 package com.pf.healthybox.domain.baseInformation;
 
 
-import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.AuditingFields;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/pf/healthybox/domain/constant/BoardCategory.java
+++ b/src/main/java/com/pf/healthybox/domain/constant/BoardCategory.java
@@ -1,0 +1,20 @@
+package com.pf.healthybox.domain.constant;
+
+import lombok.Getter;
+
+public enum BoardCategory {
+
+    NT("공지사항"),
+    EV("이벤트"),
+    TOA("홈페이지 문의"),
+    TOS("판매자 문의"),
+    FAQ("FAQ"),
+    RE("후기");
+
+    @Getter private final String description;
+
+    BoardCategory(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/constant/BoardGroup.java
+++ b/src/main/java/com/pf/healthybox/domain/constant/BoardGroup.java
@@ -1,0 +1,18 @@
+package com.pf.healthybox.domain.constant;
+
+import lombok.Getter;
+
+public enum BoardGroup {
+
+    NT("공지사항"),
+    EV("이벤트"),
+    QA("문의"),
+    RE("후기");
+
+    @Getter private final String description;
+
+    BoardGroup(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/constant/DeliveryFlag.java
+++ b/src/main/java/com/pf/healthybox/domain/constant/DeliveryFlag.java
@@ -1,0 +1,15 @@
+package com.pf.healthybox.domain.constant;
+
+import lombok.Getter;
+
+public enum DeliveryFlag {
+
+    NEW("단건 배송 정보"),
+    DEF("기본 배송 정보");
+
+    @Getter private final String description;
+
+    DeliveryFlag(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/pf/healthybox/domain/constant/PayMethod.java
+++ b/src/main/java/com/pf/healthybox/domain/constant/PayMethod.java
@@ -1,0 +1,16 @@
+package com.pf.healthybox.domain.constant;
+
+import lombok.Getter;
+
+public enum PayMethod {
+
+    CARD("카드결제"),
+    CASH("현금결제");
+
+    @Getter private final String description;
+
+    PayMethod(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/constant/Status.java
+++ b/src/main/java/com/pf/healthybox/domain/constant/Status.java
@@ -1,0 +1,22 @@
+package com.pf.healthybox.domain.constant;
+
+import lombok.Getter;
+
+public enum Status {
+
+    ORDERED("주문"),
+    BEFOREDELIVERY("출고"),
+    DELIVERING("배송중"),
+    AFTERDELIVERY("배송완료"),
+    RETURN("반품"),
+    EXCHANGE("교환"),
+    CANCEL("취소");
+
+    @Getter
+    private final String description;
+
+    Status(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/domain/orderInformation/OiOrder.java
+++ b/src/main/java/com/pf/healthybox/domain/orderInformation/OiOrder.java
@@ -1,6 +1,6 @@
 package com.pf.healthybox.domain.orderInformation;
 
-import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.AuditingFields;
 import com.pf.healthybox.domain.config.PayMethod;
 import com.pf.healthybox.domain.config.Status;
 import lombok.Getter;

--- a/src/main/java/com/pf/healthybox/domain/productInformation/PiProduct.java
+++ b/src/main/java/com/pf/healthybox/domain/productInformation/PiProduct.java
@@ -1,10 +1,9 @@
 package com.pf.healthybox.domain.productInformation;
 
-import com.pf.healthybox.domain.config.AuditingFields;
+import com.pf.healthybox.domain.AuditingFields;
 import lombok.*;
 
 import javax.persistence.*;
-import java.io.Serializable;
 import java.util.Objects;
 
 @Getter

--- a/src/main/java/com/pf/healthybox/dto/baseInformationDto/BiUserDto.java
+++ b/src/main/java/com/pf/healthybox/dto/baseInformationDto/BiUserDto.java
@@ -1,0 +1,50 @@
+package com.pf.healthybox.dto.baseInformationDto;
+
+import com.pf.healthybox.domain.baseInformation.BiUser;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record BiUserDto(
+        String userId,
+        String userPw,
+        String authDiv,
+        String authLevel,
+        String userName,
+        String nickname,
+        String compName,
+        String zipcode,
+        String address1,
+        String address2,
+        String serialCode,
+        String phoneNumber,
+        String recoCode,
+        String isDel,
+        LocalDateTime createdAt,
+//        String createdBy,
+        LocalDateTime updatedAt
+//        String updatedBy
+) {
+
+    public static BiUserDto of(String userId, String userPw, String authDiv, String authLevel, String userName, String nickname, String compName, String zipcode, String address1, String address2, String serialCode, String phoneNumber, String recoCode, String isDel) {
+        return new BiUserDto(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel, null, null);
+    }
+
+    public static BiUserDto of(String userId, String userPw, String authDiv, String authLevel, String userName, String nickname, String compName, String zipcode, String address1, String address2, String serialCode, String phoneNumber, String recoCode, String isDel, LocalDateTime createdAt, String createdBy, LocalDateTime updatedAt, String updatedBy) {
+        return new BiUserDto(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel, createdAt, updatedAt);
+    }
+
+    // entity >> dto
+    public static BiUserDto from(BiUser entity) {
+        return new BiUserDto(
+                entity.getUserId(), entity.getUserPw(), entity.getAuthDiv(), entity.getAuthLevel(), entity.getUserName(), entity.getNickname(), entity.getCompName(), entity.getZipcode(), entity.getAddress1(), entity.getAddress2(), entity.getSerialCode(), entity.getPhoneNumber(), entity.getRecoCode(), entity.getIsDel(), entity.getCreatedAt(), entity.getUpdatedAt()
+        );
+    }
+
+    //dto >> entity
+
+    public BiUser toEntity() {
+        return BiUser.of(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel);
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/dto/productInformationDto/PiDivProductDto.java
+++ b/src/main/java/com/pf/healthybox/dto/productInformationDto/PiDivProductDto.java
@@ -1,0 +1,36 @@
+package com.pf.healthybox.dto.productInformationDto;
+
+import com.pf.healthybox.domain.productInformation.PiDivProduct;
+import com.pf.healthybox.domain.productInformation.PiDivProductPk;
+
+public record PiDivProductDto(
+        PiDivProductPkDto piDivProductPkDto,
+        String groupName,
+        String categoryName,
+        String isUsed
+) {
+
+    public static PiDivProductDto of(PiDivProductPkDto piDivProductPkDto, String groupName, String categoryName, String isUsed) {
+        return new PiDivProductDto(piDivProductPkDto, groupName, categoryName, isUsed);
+    }
+
+    // entity > dto
+    public static PiDivProductDto from(PiDivProduct entity) {
+        return new PiDivProductDto(
+                PiDivProductPkDto.from(entity.getPiDivProductPk()),
+                entity.getGroupName(),
+                entity.getCategoryName(),
+                entity.getIsUsed()
+                );
+    }
+
+    // dto >> entity
+    public PiDivProduct toEntity(PiDivProductPk piDivProductPk) {
+        return PiDivProduct.of(
+                piDivProductPk,
+                groupName,
+                categoryName,
+                isUsed
+        );
+    }
+}

--- a/src/main/java/com/pf/healthybox/dto/productInformationDto/PiDivProductPkDto.java
+++ b/src/main/java/com/pf/healthybox/dto/productInformationDto/PiDivProductPkDto.java
@@ -1,0 +1,20 @@
+package com.pf.healthybox.dto.productInformationDto;
+
+import com.pf.healthybox.domain.productInformation.PiDivProductPk;
+
+public record PiDivProductPkDto(String productGroup, String productCategory) {
+
+    public static PiDivProductPkDto of (String productGroup, String productCategory) {
+        return new PiDivProductPkDto(productGroup, productCategory);
+    }
+
+    // entity > dto
+    public static PiDivProductPkDto from(PiDivProductPk entity) {
+        return new PiDivProductPkDto(entity.getProductGroup(), entity.getProductGroup());
+    }
+
+    // dto > entity
+    public PiDivProductPk toEntity() {
+        return PiDivProductPk.of(productGroup, productCategory);
+    }
+}

--- a/src/main/java/com/pf/healthybox/dto/request/baseInformationReq/BiUserRequest.java
+++ b/src/main/java/com/pf/healthybox/dto/request/baseInformationReq/BiUserRequest.java
@@ -1,0 +1,33 @@
+package com.pf.healthybox.dto.request.baseInformationReq;
+
+import com.pf.healthybox.dto.baseInformationDto.BiUserDto;
+
+import java.io.Serializable;
+
+public record BiUserRequest(
+        String userId,
+        String userPw,
+        String authDiv,
+        String authLevel,
+        String userName,
+        String nickname,
+        String compName,
+        String zipcode,
+        String address1,
+        String address2,
+        String serialCode,
+        String phoneNumber,
+        String recoCode,
+        String isDel
+) {
+
+    public static BiUserRequest of(String userId, String userPw, String authDiv, String authLevel, String userName, String nickname, String compName, String zipcode, String address1, String address2, String serialCode, String phoneNumber, String recoCode, String isDel) {
+        return new BiUserRequest(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel);
+    }
+
+    // request >> dto
+    public BiUserDto toDto() {
+        return BiUserDto.of(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel);
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/dto/response/baseInformationRes/BiUserResponse.java
+++ b/src/main/java/com/pf/healthybox/dto/response/baseInformationRes/BiUserResponse.java
@@ -1,0 +1,33 @@
+package com.pf.healthybox.dto.response.baseInformationRes;
+
+import com.pf.healthybox.dto.baseInformationDto.BiUserDto;
+
+import java.io.Serializable;
+
+public record BiUserResponse(
+        String userId,
+        String userPw,
+        String authDiv,
+        String authLevel,
+        String userName,
+        String nickname,
+        String compName,
+        String zipcode,
+        String address1,
+        String address2,
+        String serialCode,
+        String phoneNumber,
+        String recoCode,
+        String isDel
+) {
+
+    public static BiUserResponse of(String userId, String userPw, String authDiv, String authLevel, String userName, String nickname, String compName, String zipcode, String address1, String address2, String serialCode, String phoneNumber, String recoCode, String isDel) {
+        return new BiUserResponse(userId, userPw, authDiv, authLevel, userName, nickname, compName, zipcode, address1, address2, serialCode, phoneNumber, recoCode, isDel);
+    }
+
+    // dto >> response
+    public static BiUserResponse from(BiUserDto dto) {
+        return new BiUserResponse(dto.userId(), dto.userPw(), dto.authDiv(), dto.authLevel(), dto.userName(), dto.nickname(), dto.compName(), dto.zipcode(), dto.address1(), dto.address2(), dto.serialCode(), dto.phoneNumber(), dto.recoCode(), dto.isDel());
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/dto/response/productInformationRes/PiDivProductPkResponse.java
+++ b/src/main/java/com/pf/healthybox/dto/response/productInformationRes/PiDivProductPkResponse.java
@@ -1,0 +1,16 @@
+package com.pf.healthybox.dto.response.productInformationRes;
+
+import com.pf.healthybox.dto.productInformationDto.PiDivProductPkDto;
+
+public record PiDivProductPkResponse(String productGroup, String productCategory) {
+
+    public static PiDivProductPkResponse of(String productGroup, String productCategory) {
+        return new PiDivProductPkResponse(productGroup, productCategory);
+    }
+
+    // dto > response
+    public static PiDivProductPkResponse from(PiDivProductPkDto piDivProductPkDto) {
+        return new PiDivProductPkResponse(piDivProductPkDto.productGroup(), piDivProductPkDto.productCategory());
+    }
+
+}

--- a/src/main/java/com/pf/healthybox/dto/response/productInformationRes/PiDivProductResponse.java
+++ b/src/main/java/com/pf/healthybox/dto/response/productInformationRes/PiDivProductResponse.java
@@ -1,0 +1,21 @@
+package com.pf.healthybox.dto.response.productInformationRes;
+
+import com.pf.healthybox.dto.productInformationDto.PiDivProductDto;
+
+import java.util.List;
+
+public record PiDivProductResponse(
+        String groupName,
+        List<String> categoryName
+) {
+    public static PiDivProductResponse of(String groupName, List<String> categoryName) {
+        return new PiDivProductResponse(groupName, categoryName);
+    }
+
+    public PiDivProductResponse from(PiDivProductDto dto) {
+        return new PiDivProductResponse(dto.groupName(), List.of(dto.categoryName()));
+    }
+
+
+
+}

--- a/src/main/java/com/pf/healthybox/repository/BiUserRepository.java
+++ b/src/main/java/com/pf/healthybox/repository/BiUserRepository.java
@@ -1,0 +1,10 @@
+package com.pf.healthybox.repository;
+
+import com.pf.healthybox.domain.baseInformation.BiUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BiUserRepository extends JpaRepository<BiUser, String> {
+
+    void deleteByUserIdAndUserPw(String userId, String userPw);
+
+}

--- a/src/main/java/com/pf/healthybox/service/BiUserService.java
+++ b/src/main/java/com/pf/healthybox/service/BiUserService.java
@@ -1,0 +1,47 @@
+package com.pf.healthybox.service;
+
+import com.pf.healthybox.domain.baseInformation.BiUser;
+import com.pf.healthybox.dto.baseInformationDto.BiUserDto;
+import com.pf.healthybox.dto.response.baseInformationRes.BiUserResponse;
+import com.pf.healthybox.repository.BiUserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class BiUserService {
+
+    private final BiUserRepository biUserRepository;
+
+
+    public BiUserService(BiUserRepository biUserRepository) {
+        this.biUserRepository = biUserRepository;
+    }
+
+    //회원가입 메서드
+    public void signUp(BiUserDto dto) {
+        String userId = dto.userId();
+
+        Optional<BiUser> checkUser = biUserRepository.findById(userId);
+
+        if (checkUser.isEmpty()) {
+            biUserRepository.save(dto.toEntity());
+        } else {
+            throw new RuntimeException("UserInfo is exists");
+        }
+
+    }
+
+    //회원 탈퇴 메서드
+    public void deleteUser(String userId, String userPw) {
+        biUserRepository.deleteByUserIdAndUserPw(userId, userPw);
+    }
+
+    //사용자 정보를 조회하는 메서드
+    public BiUserResponse showUserInfo(String userId) {
+        return BiUserResponse.from(BiUserDto.from(biUserRepository.getReferenceById(userId)));
+    }
+
+}

--- a/src/test/java/com/pf/healthybox/service/BiUserServiceTest.java
+++ b/src/test/java/com/pf/healthybox/service/BiUserServiceTest.java
@@ -1,0 +1,81 @@
+package com.pf.healthybox.service;
+
+import com.pf.healthybox.domain.baseInformation.BiUser;
+import com.pf.healthybox.dto.baseInformationDto.BiUserDto;
+import com.pf.healthybox.repository.BiUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 회원")
+@ExtendWith(MockitoExtension.class)
+class BiUserServiceTest {
+
+    @InjectMocks private BiUserService sut;
+
+    @Mock private BiUserRepository biUserRepository;
+
+    @DisplayName("1. 유저 정보를 입력하면 회원가입이 진행된다.")
+    @Test
+    void givenUserInfo_whenSavingUser_thenSavesUser() {
+        //given
+        BiUserDto dto = createUserDto();
+        given(biUserRepository.save(any(BiUser.class))).willReturn(createUser());
+
+        //when
+        sut.signUp(dto);
+
+        //then
+        then(biUserRepository).should().save(dto.toEntity());
+    }
+
+    @DisplayName("2. 유저 삭제를 요청하면 회원 정보가 삭제된다.")
+    @Test
+    void givenUserIdAndUserPw_whenDeletingUser_thenDeletesUser() {
+        //given
+        String userId = "testId";
+        String userPw = "testPw";
+        willDoNothing().given(biUserRepository).deleteByUserIdAndUserPw(userId,userPw);
+
+        //when
+        sut.deleteUser(userId, userPw);
+
+        //then
+        then(biUserRepository).should().deleteByUserIdAndUserPw(userId,userPw);
+
+    }
+
+    @DisplayName("3. 회원의 아이디를 통해 회원정보를 가져온다")
+    @Test
+    void givenUserId_whenRequestingUserInfo_thenResponseUserInfo() {
+        //given
+        String userId = "testId";
+        given(biUserRepository.getReferenceById(userId)).willReturn(createUser());
+
+        //when
+        sut.showUserInfo(userId);
+
+        //then
+        then(biUserRepository).should().getReferenceById(userId);
+
+    }
+
+    private BiUserDto createUserDto() {
+        return BiUserDto.of(
+            "testId", "testPw", "USE", "USE", "테스트", "테스트", "", "00000", "테스트 기본 주소", "테스트 상세 주소", "9001011111111", "01012341234", "ABC12345", "N"
+        );
+    }
+
+    private BiUser createUser() {
+        return BiUser.of(
+                "testId", "testPw", "USE", "USE", "테스트", "테스트", "", "00000", "테스트 기본 주소", "테스트 상세 주소", "9001011111111", "01012341234", "ABC12345", "N"
+        );
+    }
+
+}


### PR DESCRIPTION
회원가입 페이지에 대한 서비스와 컨트롤러 코드가 추가되었음
컨트롤러의 경우 `API 컨트롤러`로 생성되었으며 서비스는 회원가입, 회원탈퇴 서비스 로직이 생성됨
회원에 대한 Requset와 Response의 객체를 받아올 수 있는 Dto를 추가로 생성하였으며, 
회원 정보 등록을 위한 `AOP 설정`으로 `AuditingFields` 파일 추가의 정상적 사용을 위해 `JpaConfig` 파일 추가
AuditingFields의 경우 `CreatedBy`, `UpdatedBy`의 경우 Security 설정이 필요하기 때문에 나중에 리팩토링으로 추가하기로 하고 현재는 제외시킴