### PR TITLE
로그인 및 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/pf/healthybox/contoller/UserManageController.java
+++ b/src/main/java/com/pf/healthybox/contoller/UserManageController.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import javax.servlet.http.HttpServletRequest;
+
 @RequestMapping("/user")
 @Controller
 public class UserManageController { // 유저 관리에 대한 컨트롤러(회원가입, 탈퇴, 로그인, 로그아웃 등)
@@ -16,6 +18,14 @@ public class UserManageController { // 유저 관리에 대한 컨트롤러(회�
     @GetMapping("/login")
     public String showLogin() {
         return "userTemplates/login";
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpServletRequest request) {
+        if (request.getSession() != null) {
+            request.getSession().invalidate();
+        }
+        return "redirect:/";
     }
 
 }

--- a/src/main/java/com/pf/healthybox/contoller/apiController/UserManageApiController.java
+++ b/src/main/java/com/pf/healthybox/contoller/apiController/UserManageApiController.java
@@ -6,9 +6,13 @@ import com.pf.healthybox.dto.request.baseInformationReq.BiUserRequest;
 import com.pf.healthybox.dto.response.baseInformationRes.BiUserResponse;
 import com.pf.healthybox.service.BiUserService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestClientException;
 
 import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 @Slf4j
 @RequestMapping("/api/user-manage")
@@ -21,6 +25,7 @@ public class UserManageApiController {
         this.biUserService = biUserService;
     }
 
+    // 회원가입 페이지 //
     //회원가입
     @PostMapping("/sign-up")
     public void signUp(@RequestBody BiUserRequest req) {
@@ -36,11 +41,25 @@ public class UserManageApiController {
         }
     }
 
-
     //ID 중복검사
     @GetMapping("/confirmId/{userId}")
     public Boolean confirmId(@PathVariable String userId) {
         return biUserService.confirmId(userId);
+    }
+
+
+    // 로그인 페이지 //
+    //로그인 기능
+    @PostMapping("/login")
+    public Boolean login(@RequestParam String userId, @RequestParam String userPw, HttpServletRequest request) {
+        BiUser user =  biUserService.login(userId, userPw);
+
+        if (user != null) {
+            HttpSession session = request.getSession();
+            session.setAttribute("loginUser", user);
+        }
+
+        return (user != null);
     }
 
 

--- a/src/main/java/com/pf/healthybox/service/BiUserService.java
+++ b/src/main/java/com/pf/healthybox/service/BiUserService.java
@@ -79,4 +79,9 @@ public class BiUserService {
         }
     }
 
+    public BiUser login(String userId, String userPw) {
+        return biUserRepository.findById(userId)
+                .filter((data) -> data.getUserPw().equals(userPw))
+                .orElse(null);
+    }
 }

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -1,0 +1,28 @@
+/* 로그인 API */
+$(document).on("click", "#loginBtn", function () {
+    console.log('hello')
+    let input_userId = $('#floatingInput').val();
+    let input_userPassword = $('#floatingPassword').val();
+
+    $.ajax({
+        url: "/api/user-manage/login?userId="+input_userId+"&userPw="+input_userPassword,
+        method: "POST",
+
+        success: function (data) {
+            if (data) {
+                location.replace('/')
+            } else {
+                $('#warningAccount').removeAttr('hidden');
+                $('#inputPw').val('').focus();
+            }
+        },
+        error: function (request, status, error) {
+            console.log("에러");
+            let errorLog = JSON.parse(request.responseText);
+            console.log(errorLog.message())
+        },
+        complete: function () {
+            console.log("완료");
+        }
+    })
+});

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -5,6 +5,7 @@
     <meta name="description" content="">
     <meta name="author" content="JH">
     <title>HEADER</title>
+
 </head>
 <body>
 
@@ -16,8 +17,14 @@
                 </a>
 
                 <div id="userMenu" class="col-md-3 text-end">
-                    <button id="loginBtn" type="button" class="btn btn-outline-success me-2">Login</button>
-                    <button id="signUpBtn" type="button" class="btn btn-success">Sign-up</button>
+                    <div id="sessionOn">
+                        <button id="loginBtnSession" type="button" class="btn btn-outline-success me-2">Login</button>
+                        <button id="signUpBtnSession" type="button" class="btn btn-success">Sign-up</button>
+                    </div>
+                    <div id="sessionOut">
+                        <button id="loginBtnUnSession" type="button" class="btn btn-outline-success me-2">userId</button>
+                        <button id="signUpBtnUnSession" type="button" class="btn btn-success">Logout</button>
+                    </div>
                 </div>
             </div>
 

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#signUpBtn" th:onclick="|window.location.href='/user/signUp'|"/>
-    <attr sel="#loginBtn" th:onclick="|window.location.href='/user/login'|"/>
+    <attr sel="#userMenu">
+        <attr sel="#sessionOn" th:if="${session.loginUser == null}">
+            <attr sel="#loginBtnSession" th:text="Log-In" th:onclick="|location.href='@{/user/login}'|"/>
+            <attr sel="#signUpBtnSession" th:text="Sign-Up" th:onclick="|location.href='@{/user/signUp}'|"/>
+        </attr>
+        <attr sel="#sessionOut" th:unless="${session.loginUser == null}">
+            <attr sel="#loginBtnUnSession" th:text="${session.loginUser.getUserName()}" th:onclick="|location.href='@{/mypage/}'|"/>-->
+            <attr sel="#signUpBtnUnSession" th:text="Log-Out" th:onclick="|location.href='@{/user/logout}'|"/>
+        </attr>
+    </attr>
 </thlogic>

--- a/src/main/resources/templates/userTemplates/login.html
+++ b/src/main/resources/templates/userTemplates/login.html
@@ -6,6 +6,12 @@
     <meta name="author" content="JH">
     <title>Healthy Box</title>
 
+    <!-- BootStrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+
+    <!-- jQuery -->
+    <script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>
+
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="/css/colors.css" rel="stylesheet">
     <link href="/css/compProperties.css" rel="stylesheet">
@@ -19,7 +25,7 @@
     </header>
 
     <main class="container d-flex flex-wrap align-items-center justify-content-center py-4 bg-light">
-        <form class="col-3 align-items-center justify-content-center text-center" >
+        <div class="col-3 align-items-center justify-content-center text-center" >
             <h4 class="mb-6">Login</h4>
 
             <div class="borderTop my-2"></div>
@@ -39,8 +45,11 @@
                     <input type="checkbox" value="remember-me"> Remember me
                 </label>
             </div>
+            <div id="warningAccount" class="text-center" hidden>
+                <p class="text-danger font-weight-bold" >ID 또는 비밀번호가 틀렸습니다.</p>
+            </div>
             <div class="d-flex flex-wrap align-items-center justify-content-center">
-                <button class="joinBtn" type="submit">Log in</button>
+                <button id="loginBtn" class="joinBtn" type="button">Log in</button>
                 <div class="mx-2"></div>
                 <a href="/user/signUp" class="joinATag">Sign-Up</a>
             </div>
@@ -49,13 +58,17 @@
                 <div class="mx-2"></div>
                 <a href="#" class="loginATag">비밀번호 찾기</a>
             </div>
-        </form>
+        </div>
     </main>
 
     <footer id="footer">
         <hr>
         푸터 삽입부
     </footer>
+
+    <script src="/js/login.js"></script>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## 로그인 및 로그아웃 기능 추가
* API 컨트롤러를 통해 로그인 사용 가능하도록 기능 추가
  * 로그인시 로그인 한 사용자 객체 세션에 저장되어 활용됨
* 로그아웃의 경우 일반 Controller를 통해 등록된 세션 삭제 후 `index.html`로 Redirect
* 로그인 및 로그아웃이 발생할 때 상단의 버튼 명칭 변경
  * 로그인 > 마이페이지 이동을 위한 사용자 이름으로 변경
  * 회원가입 > 로그아웃

This closes #30 