### PR TITLE
#75 - 헤로쿠 설정파일 중 gradle.build 파일 오타 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,6 @@ clean {
 //Heorku
 jar {
     manifest {
-        attributes('Main-Class': 'com.pf.healthbox.HealthBoxApplication')
+        attributes('Main-Class': 'com.pf.healthbox.HealthyBoxApplication')
     }
 }


### PR DESCRIPTION
`gradle.build`에서 `ApplicationName`에 오타가 있어서 수정