### PR TITLE
#78 - 오류 수정으로 마이페이지의 모든 부분 반영

### DIFF
--- a/src/main/resources/templates/myPageTemplates/myPageBasket.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageBasket.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <attr sel="#basketTableBody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="basket:${basketList}">

--- a/src/main/resources/templates/myPageTemplates/myPageCheckPw.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageCheckPw.th.xml
@@ -2,5 +2,5 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 </thlogic>

--- a/src/main/resources/templates/myPageTemplates/myPageDelivery.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageDelivery.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <attr sel="#defaultDelivery" th:object="${defaultDelivery}">
         <attr sel="#defaultName" th:text="*{deliveryName}"/>

--- a/src/main/resources/templates/myPageTemplates/myPageModifyUser.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageModifyUser.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <!-- session을 통한 user객체 반환 -->
     <attr sel="#userId" th:value="${session.loginUser.getUserId()}"/>

--- a/src/main/resources/templates/myPageTemplates/myPageOrderDetail.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageOrderDetail.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <attr sel="#orderItemListBody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="detail:${details}">

--- a/src/main/resources/templates/myPageTemplates/myPageOrderDetailStatusChange.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageOrderDetailStatusChange.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <attr sel="#orderItemListBody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="detail:${details}">

--- a/src/main/resources/templates/myPageTemplates/myPagePoint.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPagePoint.th.xml
@@ -2,7 +2,7 @@
 <thlogic>
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
-    <attr sel="#myPageNav" th:replace="/myPageTemplates/myPageNav :: #myPageNavigation"/>
+    <attr sel="#myPageNav" th:replace="myPageTemplates/myPageNav :: #myPageNavigation"/>
 
     <attr sel="#pointDetail">
         <attr sel="#allPoint" th:text="${allPoint}"/>


### PR DESCRIPTION
디커플링 로직을 통해 `myPageDiv.html`을 `replace`하는 부분에서 path 지정 방식에 차이점이 있었음 로컬환경에서 테스트 할 때는 `/`로 시작하였지만, 배포환경에서는 `/`가 들어갈 경우 경로 인식을 못해서 해당 에러가 지속적으로 발생했었음

참고 에러 수정 내역 #95 