### PR TITLE
#100 - 장바구니 오류 수정

### DIFF
--- a/src/main/java/com/pf/healthybox/service/OiBasketService.java
+++ b/src/main/java/com/pf/healthybox/service/OiBasketService.java
@@ -48,7 +48,7 @@ public class OiBasketService {
         Integer deliveryCost = 0;
         for (Tuple tuple : tuples) {
             amount += tuple.get(0, Integer.class);
-            deliveryCost += tuple.get(1, Integer.class);
+            deliveryCost += (tuple.get(0, Integer.class) == 0 ? 0 :tuple.get(1, Integer.class));
         }
 
         return List.of(amount, deliveryCost);


### PR DESCRIPTION
장바구니에 등록된 아이템의 수량이 0개일 때 배송비가 3,000원 가산되는 오류 수정

This closes #100 