### PR TITLE
#119 - 정기배송 장바구니 마크업 페이지 리펙토링

### DIFF
--- a/src/main/java/com/pf/healthybox/controller/apiController/BasketApiController.java
+++ b/src/main/java/com/pf/healthybox/controller/apiController/BasketApiController.java
@@ -44,4 +44,10 @@ public class BasketApiController {
         return oiBasketService.modifySubscribeBasket(req.toDto());
     }
 
+    @DeleteMapping("/delete-subscribe-basket")
+    public boolean deleteSubscribeBasketItems(@RequestParam String userId,
+                                              @RequestParam String basketNo) {
+        return oiBasketService.deleteSubscribeBasketItems(userId, basketNo);
+    }
+
 }

--- a/src/main/java/com/pf/healthybox/repository/querydsl/OiBasketRepositoryCustom.java
+++ b/src/main/java/com/pf/healthybox/repository/querydsl/OiBasketRepositoryCustom.java
@@ -24,4 +24,6 @@ public interface OiBasketRepositoryCustom {
     String findSubscribeCodeByUserIdAndBasketNo(String userId, String basketNo);
 
     OiSubscribeBasket findByUserIdAndBasketNoAndProductIdx(String userId, String basketNo, int productIdx);
+
+    void deleteSubscribeBasketItems(String userId, String basketNo);
 }

--- a/src/main/java/com/pf/healthybox/repository/querydsl/OiBasketRepositoryCustomImpl.java
+++ b/src/main/java/com/pf/healthybox/repository/querydsl/OiBasketRepositoryCustomImpl.java
@@ -212,4 +212,13 @@ public class OiBasketRepositoryCustomImpl extends QuerydslRepositorySupport impl
                 .where(oiSubscribeBasket.productIdx.eq(productIdx), oiSubscribeBasket.userId.eq(userId), oiSubscribeBasket.basketNo.eq(basketNo))
                 .fetchOne();
     }
+
+    @Override
+    public void deleteSubscribeBasketItems(String userId, String basketNo) {
+        QOiSubscribeBasket oiSubscribeBasket = QOiSubscribeBasket.oiSubscribeBasket;
+        queryFactory
+                .delete(oiSubscribeBasket)
+                .where(oiSubscribeBasket.userId.eq(userId), oiSubscribeBasket.basketNo.eq(basketNo))
+                .execute();
+    }
 }

--- a/src/main/java/com/pf/healthybox/service/OiBasketService.java
+++ b/src/main/java/com/pf/healthybox/service/OiBasketService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -147,6 +148,16 @@ public class OiBasketService {
             entity.setQty(dto.qty());
             return true;
         } else {
+            return false;
+        }
+    }
+
+    @Transactional
+    public boolean deleteSubscribeBasketItems(String userId, String basketNo) {
+        try {
+            oiBasketRepository.deleteSubscribeBasketItems(userId, basketNo);
+            return true;
+        } catch (EntityNotFoundException e) {
             return false;
         }
     }

--- a/src/main/resources/static/css/basketCss.css
+++ b/src/main/resources/static/css/basketCss.css
@@ -40,6 +40,28 @@
     width: 12%;
 }
 
+#nameSectBtnSector {
+    width: 8%;
+}
+
+.btnDeleteSubscribeBasket {
+    border: 1px solid rgba(84,146,91,0.8);
+    border-radius: 10px;
+    background-color: rgba(84,146,91,0.5);
+    color: white;
+    padding: 5px;
+    width: 80px;
+}
+
+.btnOrderSubscribeBasket {
+    border: 1px solid rgba(84,146,91,0.8);
+    border-radius: 10px;
+    background-color: rgb(248,249,250);
+    color: rgba(84,146,91,0.8);
+    padding: 5px;
+    width: 80px;
+}
+
 #basketTableBody td {
     border-top: 1px solid rgba(83,146,91,0.2);
     padding: 7px 5px;

--- a/src/main/resources/static/js/basket.js
+++ b/src/main/resources/static/js/basket.js
@@ -96,10 +96,35 @@ $(document).on("click",".btnOrder", function () {
     location.replace("/order/single-item/" + codes);
 });
 
+/** 정기배송 리스트 js */
+/** 주문 삭제 */
+$(document).on("click", ".btnDeleteSubscribeBasket", function () {
+    let basketNo = $(this).closest('tr').find('.dataSectBasketNo').text();
+    let userId = $("#loginBtnUnSession").attr("value");
+
+    $.ajax({
+        url: "/api/basket/delete-subscribe-basket?userId="+userId+"&basketNo="+basketNo,
+        method: "DELETE",
+
+        success: function (data) {
+            if (data) {
+                location.reload();
+            }
+        },
+        error: function (request, status, error) {
+            console.log("에러");
+        },
+        complete: function () {
+            console.log("완료");
+        }
+    });
+});
+
+
 /** 정기배송 디테일 관련 js */
 /** 정기배송 리스트 > 디테일로 이동 작업 */
 $(document).on("click", ".btnDetailInform", function () {
-    let basketNo = $(this).closest('tr').find('.itemCheck').val();
+    let basketNo = $(this).closest('tr').find('.dataSectBasketNo').text();
     $(location).attr("pathname", "/mypage/basket/subscribe/" + basketNo);
 });
 

--- a/src/main/resources/templates/myPageTemplates/myPageSubscribeBasket.html
+++ b/src/main/resources/templates/myPageTemplates/myPageSubscribeBasket.html
@@ -39,19 +39,17 @@
                         <table id="basketTable">
                             <thead id="basketTableHead">
                                 <tr>
-                                    <th id="nameSectCheckbox"><input type="checkbox" id="allCheck"></th>
-                                    <th id="nameSectSellerCode" hidden>판매자 코드</th>
                                     <th id="nameSectImg">이미지</th>
-                                    <th id="nameSectProdCode" hidden>품목 코드</th>
                                     <th id="nameSectProdName">품명</th>
                                     <th id="nameSectDeliveryDate">배송기간</th>
                                     <th id="nameSectAmount">총금액</th>
                                     <th id="nameSectDetailInform">정기배송<br>세부사항</th>
+                                    <th id="nameSectBtnSector"></th>
                                 </tr>
                             </thead>
                             <tbody id="basketTableBody">
                                 <tr>
-                                    <td class="dataSectCheckbox"><input type="checkbox" class="itemCheck" name="itemCheckBox"></td>
+                                    <td class="dataSectBasketNo" hidden></td>
                                     <td class="dataSectSellerCode" hidden>00001</td>
                                     <td class="dataSectImg"><img src="/image/products/00001.jpg" alt="제품이미지 1"></td>
                                     <td class="dataSectProdCode" hidden>00001</td>
@@ -61,48 +59,14 @@
                                     <td class="dataSectDetailInform">
                                         <button type="button" class="btnDetailInform">세부사항<br>확인·수정</button>
                                     </td>
-                                </tr>
-                                <tr>
-                                    <td class="dataSectCheckbox"><input type="checkbox" class="itemCheck" name="itemCheckBox"></td>
-                                    <td class="dataSectSellerCode" hidden>00001</td>
-                                    <td class="dataSectImg"><img src="/image/products/00001.jpg" alt="제품이미지 1"></td>
-                                    <td class="dataSectProdCode" hidden>00001</td>
-                                    <td class="dataSectProdName">품명 출력 구역</td>
-                                    <td class="dataSectDeliveryDate">2022-10-24 ~ 2022-10-31</td>
-                                    <td class="dataSectAmount">100,000 원</td>
-                                    <td class="dataSectDetailInform">
-                                        <button type="button" class="btnDetailInform">세부사항<br>확인·수정</button>
+                                    <td class="dataSectBtnSector col">
+                                        <button type="button" class="btnOrderSubscribeBasket my-1">주문</button>
+                                        <br>
+                                        <button type="button" class="btnDeleteSubscribeBasket my-1">삭제</button>
                                     </td>
                                 </tr>
                             </tbody>
                         </table>
-                    </div>
-                    <div class="d-flex flex-warp align-times-center justify-content-center border-top py-3">
-                        <table id="basketPriceTable">
-                            <thead id="basketPriceTableHead">
-                                <tr>
-                                    <th>상품 가격</th>
-                                    <th>+</th>
-                                    <th>배송비</th>
-                                    <th>=</th>
-                                    <th>총 결제 금액</th>
-                                </tr>
-                            </thead>
-                            <tbody id="basketPriceTableBody">
-                                <tr>
-                                    <td id="basketPriceAmount">200,000 원</td>
-                                    <td>+</td>
-                                    <td id="basketPriceDeliveryCost">3,000 원</td>
-                                    <td>=</td>
-                                    <td id="basketPriceTotal">203,000 원</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="d-flex flex-wrap align-items-center justify-content-center border-bottom py-3">
-                        <button type="button" id="btnOrderAll" class="btnOrder btnStyle1 mx-2">전체주문</button>
-                        <button type="button" id="btnOrderSelected" class="btnOrder btnStyle2 mx-2">선택주문</button>
-                        <button type="button" id="btnDeleteSelected" class="btnStyle1 mx-2">선택삭제</button>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/myPageTemplates/myPageSubscribeBasket.th.xml
+++ b/src/main/resources/templates/myPageTemplates/myPageSubscribeBasket.th.xml
@@ -6,7 +6,7 @@
 
     <attr sel="#basketTableBody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="basket:${basketList}">
-            <attr sel=".itemCheck" th:value="${basket.basketNo}"/>
+            <attr sel=".dataSectBasketNo" th:text="${basket.basketNo}"/>
             <attr sel=".dataSectSellerCode" th:text="${basket.sellerCode}"/>
             <attr sel=".dataSectImg/img" th:src="@{'/image/subscribeCodes/'+${basket.subscribeCode}+'.jpg'}" th:alt="${basket.subscribeCode}"/>
             <attr sel=".dataSectProdCode" th:text="${basket.subscribeCode}"/>


### PR DESCRIPTION
* 정기배송 장바구니 마크업 수정
  * 하단 버튼 메뉴 삭제(전체 주문, 선택 주문, 선택 삭제)
  * 체크박스 삭제
  * 테이블 우측 주문, 삭제 버튼 생성 및 활성화
    * 주문 버튼의 활성화는 이슈를 새로 생성해서 정기배송 주문 페이지 생성과 함께 진행
  * 삭제 버튼 활성화

This closes #119 